### PR TITLE
Ring polymer cellboundary

### DIFF
--- a/src/cells.jl
+++ b/src/cells.jl
@@ -54,15 +54,15 @@ function set_vectors!(cell::PeriodicCell, vectors::AbstractMatrix)
     cell.inverse .= inv(cell.vectors)
 end
 
-function apply_cell_boundaries!(cell::PeriodicCell, R::AbstractArray{T, 3})
+function apply_cell_boundaries!(cell::PeriodicCell, R::AbstractArray{T,3}) where {T}
     @views for i in axes(R, 3) # beads
-        apply_cell_boundaries!(cell, R[:,:,i])
+        apply_cell_boundaries!(cell, R[:, :, i])
     end
 end
 
 function apply_cell_boundaries!(cell::PeriodicCell, R::AbstractMatrix)
     @views for i in axes(R, 2) # atoms
-        apply_cell_boundaries!(cell, R[:,i])
+        apply_cell_boundaries!(cell, R[:, i])
     end
 end
 apply_cell_boundaries!(::InfiniteCell, ::AbstractArray) = nothing
@@ -77,9 +77,9 @@ function apply_cell_boundaries!(cell::PeriodicCell, R::AbstractVector)
     mul!(R, cell.vectors, cell.tmp_vector1)
 end
 
-function check_atoms_in_cell(cell::PeriodicCell, R::AbstractArray{T,3})
+function check_atoms_in_cell(cell::PeriodicCell, R::AbstractArray{T,3}) where {T}
     @views for i in axes(R, 3) # beads
-        if !check_atoms_in_cell(cell, R[:,:,i])
+        if !check_atoms_in_cell(cell, R[:, :, i])
             return false
         end
     end
@@ -93,7 +93,7 @@ True if all atoms are inside the cell, false otherwise.
 """
 function check_atoms_in_cell(cell::PeriodicCell, R::AbstractMatrix)::Bool
     @views for i in axes(R, 2) # atoms
-        mul!(cell.tmp_vector1, cell.inverse, R[:,i])
+        mul!(cell.tmp_vector1, cell.inverse, R[:, i])
         @. cell.tmp_bools = (cell.tmp_vector1 > 1) | (cell.tmp_vector1 < 0)
         any(cell.tmp_bools) && return false
     end

--- a/src/cells.jl
+++ b/src/cells.jl
@@ -38,11 +38,11 @@ Base.eltype(::PeriodicCell{T}) where {T} = T
 
 function PeriodicCell(vectors::AbstractMatrix)
     vectors = austrip.(vectors)
-    PeriodicCell{eltype(vectors)}(vectors, [true, true, true]) 
+    PeriodicCell{eltype(vectors)}(vectors, [true, true, true])
 end
 
 function PeriodicCell(vectors::AbstractMatrix{<:Integer})
-    PeriodicCell{Float64}(vectors, [true, true, true]) 
+    PeriodicCell{Float64}(vectors, [true, true, true])
 end
 
 function set_periodicity!(cell::PeriodicCell, periodicity::AbstractVector{Bool})
@@ -52,6 +52,12 @@ end
 function set_vectors!(cell::PeriodicCell, vectors::AbstractMatrix)
     cell.vectors .= vectors
     cell.inverse .= inv(cell.vectors)
+end
+
+function apply_cell_boundaries!(cell::PeriodicCell, R::AbstractArray{T, 3})
+    @views for i in axes(R, 3) # beads
+        apply_cell_boundaries!(cell, R[:,:,i])
+    end
 end
 
 function apply_cell_boundaries!(cell::PeriodicCell, R::AbstractMatrix)
@@ -69,6 +75,15 @@ function apply_cell_boundaries!(cell::PeriodicCell, R::AbstractVector)
         end
     end
     mul!(R, cell.vectors, cell.tmp_vector1)
+end
+
+function check_atoms_in_cell(cell::PeriodicCell, R::AbstractArray{T,3})
+    @views for i in axes(R, 3) # beads
+        if !check_atoms_in_cell(cell, R[:,:,i])
+            return false
+        end
+    end
+    return true
 end
 
 """


### PR DESCRIPTION
Fixes #8 by adding additional methods to apply cell boundaries to 3D arrays generated in Ring-polymer simulations. 