### PR TITLE
Compatibility with AtomsBase v0.4, ExtXYZ v0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCBase"
 uuid = "78c76ebc-5665-4934-b512-82d81b5cbfb7"
 authors = ["James Gardner <james.gardner1421@gmail.com> and contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
-AtomsBase = "0.3"
+AtomsBase = "0.4"
 Distances = "0.10"
 ExtXYZ = "0.1"
 PeriodicTable = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 [compat]
 AtomsBase = "0.4"
 Distances = "0.10"
-ExtXYZ = "0.1"
+ExtXYZ = "0.2"
 PeriodicTable = "1"
 PyCall = "1"
 Requires = "1"


### PR DESCRIPTION
AtomsBase v0.4 introduced breaking changes to the interface for periodic boundary conditions. 

As a result, this update will drop compatibility for AtomsBase v0.3 and support AtomsBase v0.4 only. 