### PR TITLE
Fix PyCall/PythonCall import bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCBase"
 uuid = "78c76ebc-5665-4934-b512-82d81b5cbfb7"
 authors = ["James Gardner <james.gardner1421@gmail.com> and contributors"]
-version = "0.2.10"
+version = "0.3.0"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/src/io/PyCall-ase.jl
+++ b/src/io/PyCall-ase.jl
@@ -1,21 +1,21 @@
 
-using .PyCall
+import .PyCall
 using Unitful, UnitfulAtomic
 
 export convert_from_ase_atoms
 export convert_to_ase_atoms
 
-const ase = PyNULL()
-copy!(ase, pyimport_conda("ase", "ase", "conda-forge"))
+const ase_pycall = PyCall.PyNULL()
+copy!(ase_pycall, PyCall.pyimport_conda("ase", "ase", "conda-forge"))
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix) =
-    ase.Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
+    ase_pycall.Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix, ::InfiniteCell) =
     convert_to_ase_atoms(atoms, R)
 
 function convert_to_ase_atoms(atoms::Atoms, R::Matrix, cell::PeriodicCell)
-    ase.Atoms(
+    ase_pycall.Atoms(
         positions=ustrip.(u"Å", R'u"bohr"),
         cell=ustrip.(u"Å", cell.vectors'u"bohr"),
         symbols=string.(atoms.types),
@@ -26,14 +26,14 @@ function convert_to_ase_atoms(atoms::Atoms, R::Vector{<:Matrix}, cell::AbstractC
     convert_to_ase_atoms.(Ref(atoms), R, Ref(cell))
 end
 
-convert_from_ase_atoms(ase_atoms::PyObject) =
+convert_from_ase_atoms(ase_atoms::PyCall.PyObject) =
     Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms)
 
-Atoms(ase_atoms::PyObject) = Atoms{Float64}(Symbol.(ase_atoms.get_chemical_symbols()))
+Atoms(ase_atoms::PyCall.PyObject) = Atoms{Float64}(Symbol.(ase_atoms.get_chemical_symbols()))
 
-positions(ase_atoms::PyObject) = austrip.(ase_atoms.get_positions()'u"Å")
+positions(ase_atoms::PyCall.PyObject) = austrip.(ase_atoms.get_positions()'u"Å")
 
-function Cell(ase_atoms::PyObject)
+function Cell(ase_atoms::PyCall.PyObject)
     if all(ase_atoms.cell.array .== 0)
         return InfiniteCell()
     else

--- a/src/io/PythonCall-ase.jl
+++ b/src/io/PythonCall-ase.jl
@@ -1,11 +1,11 @@
 
-using .PythonCall
+import .PythonCall
 using Unitful, UnitfulAtomic
 
 export convert_from_ase_atoms
 export convert_to_ase_atoms
 
-const ase = pyimport("ase")
+const ase = PythonCall.pyimport("ase")
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix) =
     ase.Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
@@ -28,14 +28,14 @@ end
 convert_from_ase_atoms(ase_atoms::Py) =
     Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms)
 
-Atoms(ase_atoms::Py) = Atoms{Float64}(Symbol.(PyList(ase_atoms.get_chemical_symbols())))
+Atoms(ase_atoms::PythonCall.Py) = Atoms{Float64}(Symbol.(PythonCall.PyList(ase_atoms.get_chemical_symbols())))
 
-positions(ase_atoms::Py) = austrip.(PyArray(ase_atoms.get_positions())'u"Å")
+positions(ase_atoms::PythonCall.Py) = austrip.(PythonCall.PyArray(ase_atoms.get_positions())'u"Å")
 
-function Cell(ase_atoms::Py)
-    if all(PyArray(ase_atoms.cell.array) .== 0)
+function Cell(ase_atoms::PythonCall.Py)
+    if all(PythonCall.PyArray(ase_atoms.cell.array) .== 0)
         return InfiniteCell()
     else
-        return PeriodicCell{Float64}(austrip.(PyArray(ase_atoms.cell.array)'u"Å"), [Bool(x) for x in ase_atoms.pbc])
+        return PeriodicCell{Float64}(austrip.(PythonCall.PyArray(ase_atoms.cell.array)'u"Å"), [Bool(x) for x in ase_atoms.pbc])
     end
 end


### PR DESCRIPTION
If PythonCall and PyCall coexist in a project and PythonCall is loaded with `JULIA_PYTHONCALL_EXE=@PyCall` set, NQCBase tries to load PythonCall and PyCall compatible methods from the ASE interface, leading to clashes between the two. 

This should be fixed here. 