### PR TITLE
Namespace clash between PyCall / PythonCall

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NQCBase"
 uuid = "78c76ebc-5665-4934-b512-82d81b5cbfb7"
 authors = ["James Gardner <james.gardner1421@gmail.com> and contributors"]
-version = "0.2.9"
+version = "0.2.11"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/Project.toml
+++ b/Project.toml
@@ -15,9 +15,9 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [compat]
-AtomsBase = "0.4"
+AtomsBase = "0.3"
 Distances = "0.10"
-ExtXYZ = "0.2"
+ExtXYZ = "0.1"
 PeriodicTable = "1"
 PyCall = "1"
 Requires = "1"

--- a/src/NQCBase.jl
+++ b/src/NQCBase.jl
@@ -9,7 +9,7 @@ include("atoms.jl")
 include("cells.jl")
 include("io/extxyz.jl")
 
-function __init__()
+function __init__() # Conditional loading of IO extensions if said packages are available. Import these before NQCBase for the interfaces to load properly. 
     @require PyCall="438e738f-606a-5dbb-bf0a-cddfbfd45ab0" @eval include("io/PyCall-ase.jl")
     @require PythonCall="6099a3de-0909-46bc-b1f4-468b9a2dfc0d" @eval include("io/PythonCall-ase.jl")
 end

--- a/src/io/PyCall-ase.jl
+++ b/src/io/PyCall-ase.jl
@@ -1,21 +1,21 @@
 
-using .PyCall
+import .PyCall
 using Unitful, UnitfulAtomic
 
 export convert_from_ase_atoms
 export convert_to_ase_atoms
 
-const ase = PyNULL()
-copy!(ase, pyimport_conda("ase", "ase", "conda-forge"))
+const ase_pycall = PyCall.PyNULL()
+copy!(ase_pycall, PyCall.pyimport_conda("ase", "ase", "conda-forge"))
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix) =
-    ase.Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
+    ase_pycall.Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix, ::InfiniteCell) =
     convert_to_ase_atoms(atoms, R)
 
 function convert_to_ase_atoms(atoms::Atoms, R::Matrix, cell::PeriodicCell)
-    ase.Atoms(
+    ase_pycall.Atoms(
         positions=ustrip.(u"Å", R'u"bohr"),
         cell=ustrip.(u"Å", cell.vectors'u"bohr"),
         symbols=string.(atoms.types),
@@ -26,14 +26,14 @@ function convert_to_ase_atoms(atoms::Atoms, R::Vector{<:Matrix}, cell::AbstractC
     convert_to_ase_atoms.(Ref(atoms), R, Ref(cell))
 end
 
-convert_from_ase_atoms(ase_atoms::PyObject) =
+convert_from_ase_atoms(ase_atoms::PyCall.PyObject) =
     Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms)
 
-Atoms(ase_atoms::PyObject) = Atoms{Float64}(Symbol.(ase_atoms.get_chemical_symbols()))
+Atoms(ase_atoms::PyCall.PyObject) = Atoms{Float64}(Symbol.(ase_atoms.get_chemical_symbols()))
 
-positions(ase_atoms::PyObject) = austrip.(ase_atoms.get_positions()'u"Å")
+positions(ase_atoms::PyCall.PyObject) = austrip.(ase_atoms.get_positions()'u"Å")
 
-function Cell(ase_atoms::PyObject)
+function Cell(ase_atoms::PyCall.PyObject)
     if all(ase_atoms.cell.array .== 0)
         return InfiniteCell()
     else

--- a/src/io/PythonCall-ase.jl
+++ b/src/io/PythonCall-ase.jl
@@ -1,11 +1,11 @@
 
-using .PythonCall
+import .PythonCall
 using Unitful, UnitfulAtomic
 
 export convert_from_ase_atoms
 export convert_to_ase_atoms
 
-const ase = pyimport("ase")
+const ase = PythonCall.pyimport("ase")
 
 convert_to_ase_atoms(atoms::Atoms, R::Matrix) =
     ase.Atoms(positions=ustrip.(u"Å", R'u"bohr"), symbols=string.(atoms.types))
@@ -28,14 +28,14 @@ end
 convert_from_ase_atoms(ase_atoms::Py) =
     Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms)
 
-Atoms(ase_atoms::Py) = Atoms{Float64}(Symbol.(PyList(ase_atoms.get_chemical_symbols())))
+Atoms(ase_atoms::PythonCall.Py) = Atoms{Float64}(Symbol.(PythonCall.PyList(ase_atoms.get_chemical_symbols())))
 
-positions(ase_atoms::Py) = austrip.(PyArray(ase_atoms.get_positions())'u"Å")
+positions(ase_atoms::PythonCall.Py) = austrip.(PythonCall.PyArray(ase_atoms.get_positions())'u"Å")
 
-function Cell(ase_atoms::Py)
-    if all(PyArray(ase_atoms.cell.array) .== 0)
+function Cell(ase_atoms::PythonCall.Py)
+    if all(PythonCall.PyArray(ase_atoms.cell.array) .== 0)
         return InfiniteCell()
     else
-        return PeriodicCell{Float64}(austrip.(PyArray(ase_atoms.cell.array)'u"Å"), [Bool(x) for x in ase_atoms.pbc])
+        return PeriodicCell{Float64}(austrip.(PythonCall.PyArray(ase_atoms.cell.array)'u"Å"), [Bool(x) for x in ase_atoms.pbc])
     end
 end

--- a/src/io/PythonCall-ase.jl
+++ b/src/io/PythonCall-ase.jl
@@ -25,7 +25,7 @@ function convert_to_ase_atoms(atoms::Atoms, R::Vector{<:Matrix}, cell::AbstractC
     convert_to_ase_atoms.(Ref(atoms), R, Ref(cell))
 end
 
-convert_from_ase_atoms(ase_atoms::Py) =
+convert_from_ase_atoms(ase_atoms::PythonCall.Py) =
     Atoms(ase_atoms), positions(ase_atoms), Cell(ase_atoms)
 
 Atoms(ase_atoms::PythonCall.Py) = Atoms{Float64}(Symbol.(PythonCall.PyList(ase_atoms.get_chemical_symbols())))


### PR DESCRIPTION
Identical to #19 , but based on older AtomsBase version, since there is dependency clash between the newer version and ACE packages. I will fix this going forward by setting NQCBase versions compatible with AtomsBase v0.4 and ExtXYZ v0.2 as **v0.3.X** and backward compatible releases with **v0.2.x**. 