### PR TITLE
✨ Add Structure type and convenience functions

### DIFF
--- a/src/NQCBase.jl
+++ b/src/NQCBase.jl
@@ -4,15 +4,41 @@ using PeriodicTable
 using Unitful, UnitfulAtomic
 using Requires
 
+# Basic types for atomic structures
 include("unit_conversions.jl")
 include("atoms.jl")
 include("cells.jl")
-include("io/extxyz.jl")
 
+# Convenience Structure type
+
+"""
+    Structure{T}
+
+Structures are storage types to keep atoms, positions, cells and further information in one place. 
+Many functions in the NQCD packages use only parts of the structure information for efficiency, e.g. integration routines, but it can be convenient to have it all in one type. 
+
+If you are developing in NQCD, please include multiple dispatch versions of your functions using Structure types where this would be convenient to the user. 
+"""
+struct Structure{T}
+    atoms::NQCBase.Atoms # Atoms object
+    positions::AbstractMatrix{T} # Positions matrix in atomic units, each column containing one atom's positions
+    cell::AbstractCell # Unit cell object
+    info::Dict{String, Any} # Other structure information, e.g. from an ExtXYZ header
+end
+Structure(atoms::NQCBase.Atoms, positions::AbstractMatrix, cell::AbstractCell) = Structure(atoms, positions, cell, Dict{String, Any}())
+
+# I/O Interfaces
+include("io/extxyz.jl")
 include("atoms_base.jl")
+
+
 export Cell
 export System
 export Trajectory
 export Position, Velocity
+
+
+
+
 
 end

--- a/src/atoms_base.jl
+++ b/src/atoms_base.jl
@@ -48,6 +48,9 @@ function System(atoms::NQCBase.Atoms, position::AbstractMatrix, cell::AbstractCe
     output_atoms = AtomsBaseAtoms(atoms, position)
     return build_system(output_atoms, cell)
 end
+function System(structure::NQCBase.Structure)
+    return System(structure.atoms, structure.positions, structure.cell)
+end
 
 function System(atoms::NQCBase.Atoms, position::AbstractMatrix, velocity::AbstractMatrix, cell::AbstractCell=InfiniteCell())
     output_atoms = AtomsBaseAtoms(atoms, position, velocity)

--- a/src/io/extxyz.jl
+++ b/src/io/extxyz.jl
@@ -36,6 +36,22 @@ function read_extxyz(file)
     return atoms, positions, cell
 end
 
+"""
+    Structure(file::String)
+
+Use ExtXYZ.jl to read a structure from an ExtXYZ file
+"""
+function Structure(file::String, index=1)
+    eyxz_structure = ExtXYZ.read_frames(file)
+    atoms, positions, cell = from_extxyz_dict(exyz_structure)[index]
+    return Structure(
+        atoms,
+        positions,
+        cell,
+        exyz_structure[index]["info"]
+    )
+end
+
 function to_extxyz_dict(atoms::Atoms, R::Matrix, cell::PeriodicCell)
 
     dict = Dict{String, Any}()


### PR DESCRIPTION
What do people think about a `Structure` kind of type for NQCD that just
acts as a container for `Atoms`, positions and an AbstractCell ? 


**Pro:**
It's more obvious to work with when using conversion functions / IO 
interfaces from files or e.g. ase, because all of those carry that information together and having to know that the atoms are at `output[1]`, the positions at `output[2]` and the cell at `output[3]` is stupid. 
I would also have a nicer time writing plotting code.

**Con:**
It'd be yet another "atomic structure" struct. Finding a name for it 
that doesn't immediately clash with other packages is also going to be 
annoying.
(But I guess we could also just never export it and have a 
`NQCBase.Structure` or something that's also descriptive about where it 
came from)

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #30 
- <kbd>&nbsp;1&nbsp;</kbd> #29 👈 
<!-- GitButler Footer Boundary Bottom -->

